### PR TITLE
alsa: use snd_pcm_pause() on pause/resume.

### DIFF
--- a/src/sound_alsa.c
+++ b/src/sound_alsa.c
@@ -103,10 +103,12 @@ static void flush(void)
 
 static void onpause(void)
 {
+	snd_pcm_pause(pcm_handle, 1);
 }
 
 static void onresume(void)
 {
+	snd_pcm_pause(pcm_handle, 0);
 }
 
 static const char *const help[] = {


### PR DESCRIPTION
This might be a bug in alsa-jack, but when pausing in xmp-cli it just plays back the same buffer again and again ([demo](https://www.youtube.com/watch?v=qyGWphJBDvo)). Using `snd_pcm_pause()` fixes the issue.