### PR TITLE
Tell configure to detect sndio on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,7 @@ darwin*)
     AC_SUBST([XMP_DARWIN_LDFLAGS])
   fi
   ;;
-openbsd*)
+openbsd*|freebsd*)
   AC_CHECK_HEADER(sndio.h)
   if test "${ac_cv_header_sndio_h}" = "yes"; then
     AC_DEFINE(SOUND_SNDIO)


### PR DESCRIPTION
Unfortunately configure assumes it is only available on OpenBSD. Modify configure.ac to detect sndio on FreeBSD.