### PR TITLE
Add setvbuf(_IONBF) to fix terminal output for MSYS2

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -252,6 +252,7 @@ int main(int argc, char **argv)
 	gettimeofday(&tv, &tz);
 	srand(tv.tv_usec);
 #else
+	setvbuf(stderr, NULL, _IONBF, 0);
 	srand(GetTickCount());
 #endif
 


### PR DESCRIPTION
Terminal output when using xmp in MSYS2 is fairly unresponsive—typically it takes between 1-2 patterns into the song before *any* song information is printed, and the current order/row/time lags behind. The problem appears to be that xmp assumes stderr is unbuffered but, for whatever reason, MSYS2 has a fully buffered stderr. Adding an fflush() to report() in main.c makes the terminal output as responsive as it is in Linux. I don't think this is required for any of the other fprintf usages since those are always followed by report() or exit().