### PR TITLE
Spelling fix ("ommited")

### DIFF
--- a/src/xmp.1
+++ b/src/xmp.1
@@ -57,7 +57,7 @@ Amplification factor for the software mixer\&. Valid amplification factors
 range from 0 to 3. Default is 1. \&. Warning\&: higher amplification
 factors may cause distorted or noisy output\&.
 .IP "\fB\-b, \-\-bits\fP \fIbits\fP" 
-Set the software mixer resolution (8 or 16 bits)\&. If ommited,
+Set the software mixer resolution (8 or 16 bits)\&. If omitted,
 The audio device will be opened at the highest resolution available\&.
 .IP "\fB\-C, \-\-show\-comments\fP" 
 Display module comment text, if any\&.


### PR DESCRIPTION
This was flagged by Lintian, Debian's QA tool.

Signed-off-by: Stephen Kitt <steve@sk2.org>