### PR TITLE
Use apostrophes instead of acute accents

### DIFF
--- a/src/xmp.1
+++ b/src/xmp.1
@@ -116,12 +116,12 @@ Load and mix module, but discard output data (same as \-\-device=null)\&.
 .IP "\fB\-\-nocmd\fP" 
 Disable interactive commands\&.
 .IP "\fB\-o, \-\-output\-file\fP \fIfilename\fP" 
-Set the output file name when mixing to raw or WAV files\&. If \'-\' is
+Set the output file name when mixing to raw or WAV files\&. If '-' is
 given as the file name, the output will be sent to stdout\&.
 .IP "\fB\-P, \-\-pan\fP \fInum\fP" 
 Set the percentual panning amplitude\&.
 .IP "\fB\-P, \-\-default\-pan\fP \fInum\fP" 
-Set the percentual default pan setting for modules that don\'t set their
+Set the percentual default pan setting for modules that don't set their
 own pan values\&. Useful to reduce LRRL pan separation on headphones\&.
 This parameter does not affect the Amiga 500 classic mixer\&.
 .IP "\fB\-\-probe\-only\fP" 
@@ -187,7 +187,7 @@ the values\&.
 .IP "\fB\-D\fP \fIdev=device_name\fP" 
 Set the audio device to open\&. Default is /dev/dsp\&.
 .IP "\fB\-D\fP \fInosync\fP" 
-Don\'t sync the OSS audio device between modules\&.
+Don't sync the OSS audio device between modules\&.
 .PP 
 BSD driver options:
 .IP "\fB\-D\fP \fIgain=value\fP" 


### PR DESCRIPTION
In groff, \' represents an acute accent, not an apostrophe. This
replaces these with straight apostrophes.

Signed-off-by: Stephen Kitt <steve@sk2.org>